### PR TITLE
Replace gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var Aigis = require("node-aigis");
-var gutil = require("gulp-util");
+var log = require('fancy-log');
+var PluginError = require('plugin-error');
 var through = require("through2");
 var path = require("path");
 
@@ -7,13 +8,13 @@ module.exports = function(options) {
   return through.obj(function(file, enc, cb) {
     var aigis;
     var configFilePath = path.resolve(file.path);
-    gutil.log("config file: " + configFilePath);
+    log("config file: " + configFilePath);
     try {
       aigis = new Aigis(configFilePath);
       aigis.run().then(cb);
     }
     catch(e) {
-      this.emit("error", new gutil.PluginError("gulp-aigis", e.message));
+      this.emit("error", new PluginError("gulp-aigis", e.message));
       cb();
     }
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
   },
   "homepage": "https://github.com/pxgrid/gulp-aigis#readme",
   "dependencies": {
-    "gulp-util": "^3.0.6",
+    "fancy-log": "^1.3.2",
     "lodash": "^4.10.0",
     "node-aigis": "^1.3.0",
+    "plugin-error": "^1.0.1",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`gulp-util` is deprecated and should no longer be used.

See https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5